### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,7 +118,7 @@ Estimate the probability that this sample is contaminated with other genomic mat
 ###USEFUL TIPS
    The recommended flow is first indexing your reference and then align your fastq file to this reference, and then infer the population identity or you infer the contamination level.
    
-   FASTQuick was released along with pre-selected variant sites for information collection, which could be found in resource directory. If you want to use your own abitrary variant sites, you may look into the bin directory to use generate_new_matrix.sh to update your own variants set and then you can update everything you need with the auxilary tools in bin directory.
+   FASTQuick was released along with pre-selected variant sites for information collection, which could be found in resource directory. If you want to use your own abitrary variant sites, you may look into the bin directory to use generate_new_matrix.sh to update your own variants set and then you can update everything you need with the auxiliary tools in bin directory.
 ###BUGS
    List known bugs.
 ###AUTHOR


### PR DESCRIPTION
Griffan, I've corrected a typographical error in the documentation of the [FASTQuick](https://github.com/Griffan/FASTQuick) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
